### PR TITLE
Ensure save path exists

### DIFF
--- a/i3-save
+++ b/i3-save
@@ -144,6 +144,7 @@ save_workspace_programs() {
 # Don't run if the script is sourced (such as for testing)
 if [[ ${BASH_SOURCE[0]} == "${0}" ]]; then
     log "Saving current i3wm session"
+    mkdir -p "$i3_PATH"
     save_workspace_layouts
     save_workspace_programs
     log "Finished saving current i3wm session"


### PR DESCRIPTION
When using a non-standard `i3_PATH` environment variable to keep save state separate from config (e.g. `i3_PATH=$HOME/.cache/i3`), ensure the directory exists before writing files in the provided location.